### PR TITLE
Don't create fifo if already present

### DIFF
--- a/rootfs/etc/cont-init.d/00-initialize-log-fds
+++ b/rootfs/etc/cont-init.d/00-initialize-log-fds
@@ -13,6 +13,10 @@ if { s6-envuidgid -D 32768:32768 nobody s6-chown -U /var/log/nginx-error-logs }
 if { s6-chmod 2700 /var/log/nginx-error-logs }
 
 
+# Check if the logging fifos have already been created, if so we can skip the
+# next steps.
+if -n { s6-test -p /var/run/s6/nginx-access-log-fifo }
+
 # initialize fifos and put inside fdholderd
 if { mkfifo /var/run/s6/nginx-access-log-fifo }
 if


### PR DESCRIPTION
When using `S6_BEHAVIOUR_IF_STAGE2_FAILS=2`, a container will not start if any of
the stage2 scripts fail.

This is caused by the fact that `00-initialize-log-fds` script will fail if one
of the fifos has already been created. For example, this is the case when
restarting the container.

This commits checks if the fifo exists before trying to create it (using
`s6-test -p`).

**NOTE**: I only check the first fifo because I assume that all of them are created together. And also, I couldn't get a s6-test expression with multiple conditions to work. Another option would be something like this:

```
ifelse -n { s6-test -p fifo1 }
{
  if -n { s6-test -p fifo2 }
  { if { mkfifo fifo2 } }
}
{ if { mkfifo fifo1 } }
s6-true
```

But that would get complex very fast.
