### PR TITLE
fix: sometimes "random state" error thrown if .rnd not set

### DIFF
--- a/rootfs/etc/cont-init.d/01-generate-dhparam
+++ b/rootfs/etc/cont-init.d/01-generate-dhparam
@@ -1,6 +1,10 @@
 #!/usr/bin/execlineb -P
 
-s6-setuidgid nginx
 if { s6-mkdir -p /etc/nginx/certs }
 if -t { s6-test ! -f /etc/nginx/certs/dhparam.pem }
-if { openssl dhparam -out /etc/nginx/certs/dhparam.pem 2048 }
+if
+{
+  export RANDFILE .rnd
+  openssl dhparam -out /etc/nginx/certs/dhparam.pem 2048
+}
+if { s6-envuidgid nginx s6-chown -U -- /etc/nginx/certs/dhparam.pem }

--- a/rootfs/etc/cont-init.d/02-confd-onetime
+++ b/rootfs/etc/cont-init.d/02-confd-onetime
@@ -11,4 +11,4 @@ multisubstitute
   import -u CONFD_BACKEND_ARGS
   define CONFD_CHECK_CMD "/usr/sbin/nginx -t -c {{ .src }}"
 }
-confd --onetime --prefix="${CONFD_PREFIX}" --tmpl-uid="${UID}" --tmpl-gid="${GID}" --tmpl-src="/etc/nginx/nginx.conf.tmpl" --tmpl-dest="/etc/nginx/nginx.conf" --tmpl-check-cmd="${CONFD_CHECK_CMD}" ${CONFD_BACKEND} ${CONFD_BACKEND_ARGS}
+confd --onetime --prefix="${CONFD_PREFIX}" --tmpl-uid="${UID}" --tmpl-gid="${GID}" --tmpl-mode="0600" --tmpl-src="/etc/nginx/nginx.conf.tmpl" --tmpl-dest="/etc/nginx/nginx.conf" --tmpl-check-cmd="${CONFD_CHECK_CMD}" ${CONFD_BACKEND} ${CONFD_BACKEND_ARGS}


### PR DESCRIPTION
also, make nginx.conf permissions consistent with all surrounding files.
